### PR TITLE
Allow the caller to specify CSS class(es) for the icon SVG elements.

### DIFF
--- a/heroicons/templatetags/heroicons.py
+++ b/heroicons/templatetags/heroicons.py
@@ -18,5 +18,12 @@ def heroicon(icon_name, **kwargs):
 	if not result:
 		raise Exception('{} is not a valid icon!'.format(icon_name))
 	
+	clazz = None
+
+	if 'class' in kwargs:
+		clazz = kwargs['class']
+		
 	with open(result) as f: icon = f.read()
+	if clazz:
+		icon = icon.replace('<svg', f'<svg class="{clazz}"')
 	return mark_safe(icon)


### PR DESCRIPTION
Many of the TailwindUI widgets use inline heroicons styled with CSS classes on the SVG element itself. While it's almost always possible to move the tailwind classes to a parent, it's easy and mechanical to move them into a template if you can apply the classes to `svg`.

This PR adds a `class` kwarg and puts its content into a class attribute on the SVG if present. If no `class` keyword is supplied, it behaves as before.

So the following template:

```
{% heroicon 'beaker' class="w-6 h-6" %}
```

results in

```
<svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"></path>
</svg>
```
